### PR TITLE
Add `unselectable` css class

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -222,3 +222,9 @@ footer {
   -webkit-transform: translateZ(12px);
   -moz-transform: translateZ(12px);
 }
+
+.unselectable {
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10+ */
+  user-select: none;
+}

--- a/src/pot/pot/pot.ts
+++ b/src/pot/pot/pot.ts
@@ -83,7 +83,7 @@ class Pot extends Component {
               <div class="knobHolder">
                 <div class="knob"></div>
               </div>
-              <div class="nameHolder">
+              <div class="nameHolder unselectable">
                 <div class="name">${this.model.name}</div>
               </div>
             </div>`

--- a/src/stomp/box/box.ts
+++ b/src/stomp/box/box.ts
@@ -69,7 +69,7 @@ class Box extends Connectable {
     return `
         <div class="box ${className}">
           <div class="pots">${this.pots.join('')}</div>
-          <div class="name">${this.name}</div>
+          <div class="name unselectable">${this.name}</div>
           <div class="leds">${this.leds.join('')}</div>
           <div class="switches">${this.switches.join('')}</div>
         </div>`


### PR DESCRIPTION
While changing the `knob` settings, it is possible to select the name texts as attached.


<img width="995" alt="image" src="https://user-images.githubusercontent.com/57585087/215298767-993d5d45-0254-4940-b430-d8b0e61783ab.png">
